### PR TITLE
Remove deprecated let blocks

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -139,17 +139,16 @@ function addMenuItem(win) {
   removeMI();
 
   // add the new menuitem to File menu
-  let (restartMI = win.document.createElementNS(NS_XUL, "menuitem")) {
-    restartMI.setAttribute("id", fileMenuitemID);
-    restartMI.setAttribute("class", "menuitem-iconic");
-    restartMI.setAttribute("label", _("restart", getPref("locale")));
-    restartMI.setAttribute("accesskey", _("restart.accesskey", getPref("locale")));
-    restartMI.setAttribute("key", keyID);
-    restartMI.style.listStyleImage = "url('" + logo + "')";
-    restartMI.addEventListener("command", restart, true);
+  let restartMI = win.document.createElementNS(NS_XUL, "menuitem");
+  restartMI.setAttribute("id", fileMenuitemID);
+  restartMI.setAttribute("class", "menuitem-iconic");
+  restartMI.setAttribute("label", _("restart", getPref("locale")));
+  restartMI.setAttribute("accesskey", _("restart.accesskey", getPref("locale")));
+  restartMI.setAttribute("key", keyID);
+  restartMI.style.listStyleImage = "url('" + logo + "')";
+  restartMI.addEventListener("command", restart, true);
 
-    $("menu_FilePopup").insertBefore(restartMI, $("menu_FileQuitItem"));
-  }
+  $("menu_FilePopup").insertBefore(restartMI, $("menu_FileQuitItem"));
 
   unload(removeMI, win);
 }
@@ -181,14 +180,13 @@ function main(win) {
   rrKeyset.setAttribute("id", keysetID);
 
   // add hotkey
-  let (restartKey = xul("key")) {
-    restartKey.setAttribute("id", keyID);
-    restartKey.setAttribute("key", getPref("key"));
-    restartKey.setAttribute("modifiers", getPref("modifiers"));
-    restartKey.setAttribute("oncommand", "void(0);");
-    restartKey.addEventListener("command", restart, true);
-    $(XUL_APP.baseKeyset).parentNode.appendChild(rrKeyset).appendChild(restartKey);
-  }
+  let restartKey = xul("key");
+  restartKey.setAttribute("id", keyID);
+  restartKey.setAttribute("key", getPref("key"));
+  restartKey.setAttribute("modifiers", getPref("modifiers"));
+  restartKey.setAttribute("oncommand", "void(0);");
+  restartKey.addEventListener("command", restart, true);
+  $(XUL_APP.baseKeyset).parentNode.appendChild(rrKeyset).appendChild(restartKey);
 
   // add menu bar item to File menu
   addMenuItem(win);

--- a/src/includes/l10n.js
+++ b/src/includes/l10n.js
@@ -49,11 +49,10 @@ var l10n = (function(global) {
     let defaultBundle = Services.strings.createBundle(filepath(locale));
 
     let defaultBasicBundle;
-    let (locale_base = locale.match(splitter)) {
-      if (locale_base) {
-        defaultBasicBundle = Services.strings.createBundle(
-            filepath(locale_base[1]));
-      }
+    let locale_base = locale.match(splitter);
+    if (locale_base) {
+      defaultBasicBundle = Services.strings.createBundle(
+          filepath(locale_base[1]));
     }
 
     let addonsDefaultBundle =


### PR DESCRIPTION
Let blocks are now deprecated, causing console warnings to print at startup.